### PR TITLE
Render @example tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/render.js
+++ b/lib/render.js
@@ -54,7 +54,7 @@ module.exports = function(options) {
                         chainable: !!_.find(block.tags, {type: 'chainable'}),
                         private: !!_.find(block.tags, {type: 'private'}),
                         code: block.code,
-                        examples: extractMultilineTags(block.tags, 'example'),
+                        examples: _.pluck(_.filter(block.tags, {type: 'example'}), 'string'),
                         name: block.ctx ? block.ctx.name : ''
                     };
 
@@ -103,30 +103,6 @@ module.exports = function(options) {
         });
     });
 };
-
-function extractMultilineTags(tags, key) {
-
-    var results = [],
-        index = -1,
-        inTag = false;
-
-    _.each(tags, function(tag) {
-        if (tag.type === key) {
-            inTag = true;
-            index++;
-        }
-        if (inTag && tag.type === '') {
-            results[index] = results[index] || '';
-            results[index] += tag.string + '\n'
-        }
-        if (tag.type !== key && tag.type !== '') {
-            inTag = false;
-        }
-    });
-
-    return results;
-
-}
 
 function prettifyTitle(value) {
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "dox": "~0.4.4",
+    "dox": "~0.4.6",
     "optimist": "~0.6.0",
     "lodash": "~2.4.1",
     "bluebird": "~1.0.8",


### PR DESCRIPTION
It seems that `dox` was updated at v0.4.5 to support multi line tags and now returns one tag item per `@example` with all the following lines of code.

This changes `doxstrap` to render example blocks again.
