### PR TITLE
Accept multiple sources

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -18,7 +18,7 @@ optimist.describe('V', 'Verbose output');
 
 optimist.alias('s', 'source');
 optimist.default('s', 'src/**/*.js');
-optimist.describe('s', 'Source files');
+optimist.describe('s', 'Source files, accepts multiple patterns with the OS path separator');
 
 optimist.alias('o', 'output');
 optimist.describe('o', 'Directory to render output');

--- a/lib/render.js
+++ b/lib/render.js
@@ -22,7 +22,8 @@ var templatePath = path.resolve(__dirname, '..', 'template', 'default.html'),
 
 module.exports = function(options) {
 
-    var stream = gs.create([options.source]),
+    var sources = options.source.split(path.delimiter),
+        stream = gs.create(sources),
         files = [],
         docs = {};
 


### PR DESCRIPTION
Useful for cases when you need to generate documentation only for certain files within a folder:

```
doxstrap --source "lib/foo.js:lib/bar.js"
```